### PR TITLE
Form processing state

### DIFF
--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Form as FormCollection, Button } from "react-bulma-components";
 
@@ -106,15 +106,21 @@ export const validateAll = ( rawData, ...validators ) => {
 
 const fieldDefaultValuesReducer = ( values, { name, value } ) => ({
     ...values,
-    [name]: undefined === value ? value : ""
+    [name]: undefined === value ? "" : value
 });
 
-export const useFormFields = fieldsConfig => {
+export const useFormFields = (fieldsConfig, valueSource) => {
 
     const [ values, setValues ] = useState( fieldsConfig.reduce(fieldDefaultValuesReducer,{}) );
 
+    useEffect(() => {
+
+        setValues( fieldsConfig.reduce(fieldDefaultValuesReducer,{}) );
+
+    }, [ valueSource ]);
+
     return [
-        fieldsConfig.map( ({name,...field}) => ({
+        fieldsConfig.map( ({name, onMap=field=>field, ...field}) => onMap({
             ...field,
             name,
             value: values[name],
@@ -191,6 +197,7 @@ export const FormField = ( { label, type = "text", name, placeholder, value, onC
 
 const Form = ( {
     fields,
+    fieldValueSource,
     validation,
     button,
     buttonText = "Submit",
@@ -201,7 +208,7 @@ const Form = ( {
     ...props
 } ) => {
 
-    const [formFields, fieldValues] = useFormFields( fields );
+    const [formFields, fieldValues] = useFormFields( fields, fieldValueSource );
 
     const [ errors, setErrors ] = useState({});
 

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -210,14 +210,23 @@ const Form = ( {
 
     const [formFields, fieldValues] = useFormFields( fields, fieldValueSource );
 
+    const [ isProcessing, setIsProcessing ] = useState(false);
     const [ errors, setErrors ] = useState({});
+
+    const submitData = async data => {
+        setIsProcessing( true );
+        onSubmit && await onSubmit( data, setErrors );
+        setIsProcessing( false );
+    }
 
     const handleSubmit = e => {
 
         e.preventDefault();
 
+        if( isProcessing ) return;
+
         if( !validation ) {
-            onSubmit && onSubmit( fieldValues, setErrors );
+            submitData( fieldValues );
             return;
         }
 
@@ -230,7 +239,7 @@ const Form = ( {
 
         setErrors({});
 
-        onSubmit && onSubmit( data, setErrors );
+        submitData( data );
 
     }
 
@@ -248,7 +257,7 @@ const Form = ( {
             </ErrorProvider>
             {flat ? null : <hr />}
             <div className="is-flex">
-                { button ? button : <Button color="primary">{ buttonText }</Button> }
+                { button ? button : <Button color="primary" loading={isProcessing}>{ buttonText }</Button> }
                 { moreButtons }
             </div>
         </form>

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { Form as FormCollection, Button } from "react-bulma-components";
 
@@ -213,10 +213,12 @@ const Form = ( {
     const [ isProcessing, setIsProcessing ] = useState(false);
     const [ errors, setErrors ] = useState({});
 
+    const formRef = useRef();
+
     const submitData = async data => {
         setIsProcessing( true );
         onSubmit && await onSubmit( data, setErrors );
-        setIsProcessing( false );
+        if( formRef.current ) setIsProcessing( false );
     }
 
     const handleSubmit = e => {
@@ -250,7 +252,7 @@ const Form = ( {
     if(flat) classes.push("is-flat");
 
     return (
-        <form className={classes.join(" ")} onSubmit={handleSubmit} {...props}>
+        <form ref={formRef} className={classes.join(" ")} onSubmit={handleSubmit} {...props}>
             <ErrorProvider value={errors}>
                 <Error name="default" type="message" />
                 { formFields.map( field => <FormField key={field.name} inputColor={inputErrorColor} { ...field } /> ) }

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import {
     Button,
@@ -97,44 +97,8 @@ export const LoginForm = ( { afterLogin, redirect = true, email: emailStart = ""
     const login = useLogin();
     const history = useHistory();
 
-    // Form state.
-    const [ email, setEmail ] = useState( emailStart );
-    const [ password, setPassword ] = useState( "" );
-    const [ errors, setErrors ] = useState({});
-
-    // Login form fields configuration.
-    const fields = [
-        {
-            label: "Email",
-            placeholder: "Login Email",
-            name: "email",
-            type: "email",
-            value: email,
-            onChange: (e) => setEmail(e.target.value)
-        },
-        {
-            label: "Password",
-            placeholder: "Login Password",
-            name: "password",
-            type: "password",
-            value: password,
-            onChange: (e) => setPassword(e.target.value)
-        }
-    ];
-
     // Handle login submission.
-    const handleSubmit = async (e) => {
-
-        e.preventDefault();
-
-        const [ data, errors, hasErrors ] = validateLoginData({ email, password });
-
-        if( hasErrors ) {
-            setErrors( errors );
-            return;
-        }
-
-        setErrors({});
+    const handleSubmit = async ( data, setErrors ) => {
 
         try {
 
@@ -152,6 +116,25 @@ export const LoginForm = ( { afterLogin, redirect = true, email: emailStart = ""
         
     };
 
-    return <Form flat fields={fields} errors={errors} onSubmit={handleSubmit} buttonText="Login" />;
+    return <Form
+            flat
+            fields={[
+                {
+                    label: "Email",
+                    placeholder: "Login Email",
+                    type: "email",
+                    name: "email",
+                },
+                {
+                    label: "Password",
+                    placeholder: "Login Password",
+                    type: "password",
+                    name: "password",
+                }
+            ]}
+            validation={validateLoginData}
+            onSubmit={handleSubmit}
+            buttonText="Login"
+            />;
 
 };

--- a/client/src/pages/Dashboard/components/StudentCard/index.js
+++ b/client/src/pages/Dashboard/components/StudentCard/index.js
@@ -11,7 +11,7 @@ import Icon from "components/Icon";
 import Dropdown from "components/Dropdown";
 import { getDashboardAction as gda, useClassroom, useDashboardDispatch, useStaffMember } from "pages/Dashboard/store";
 import { EDIT_STUDENT, REMOVE_STUDENT } from "pages/Dashboard/store/actionsNames";
-import { usePriorityLevel } from "pages/Dashboard/utils/student";
+import { getPriorityLevel } from "pages/Dashboard/utils/student";
 
 import "./style.sass";
 
@@ -47,7 +47,7 @@ export const StudentMenu = ({ _id, name }) => {
 
 export const StudentPriorityTag = ( { level, className, ...props } ) => {
 
-    const priorityLevel = usePriorityLevel( level );
+    const priorityLevel = getPriorityLevel( level );
 
     const classes = className ? [className] : [];
     classes.push("is-light");

--- a/client/src/pages/Dashboard/components/StudentModal/components/ActivityFeed/components/CommentForm.js
+++ b/client/src/pages/Dashboard/components/StudentModal/components/ActivityFeed/components/CommentForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import Form, { createValidator } from "components/Form";
 import api from "utils/api";
@@ -10,44 +10,13 @@ const validateInviteData = createValidator({
     }
 });
 
-const useCommentFormFields = () => {
-
-    const [ state, setState ] = useState({ comment: "" });
-
-    const onChange = e => setState({ ...state, [e.target.name]: e.target.value });
-
-    const fields = [
-        {
-            placeholder: "Add a comment...",
-            name: "comment",
-            type: "textarea",
-            value: state.comment,
-            onChange
-        }
-    ];
-
-    return [ fields, state, setState ];
-
-}
-
 const CommentForm = ({ feedId }) => {
 
     const handleFeedEventResponse = useHandleFeedEventResponse(feedId);
-    const [ fields, values, setValues ] = useCommentFormFields();
-    const [ errors, setErrors ] = useState({});
 
-    const handleSubmit = async e => {
-
-        e.preventDefault();
+    const handleSubmit = async (data, setErrors) => {
 
         try {
-
-            const [ data, errors, hasErrors ] = validateInviteData(values);
-
-            if(hasErrors) {
-                setErrors(errors);
-                return
-            }
             
             handleFeedEventResponse( (await api.createComment( feedId, data )).data );
 
@@ -63,7 +32,19 @@ const CommentForm = ({ feedId }) => {
 
     return (
         <div style={{flexGrow:0}}>
-            <Form flat fields={fields} errors={errors} onSubmit={handleSubmit} buttonText="comment" />
+            <Form
+                flat
+                fields={[
+                    {
+                        placeholder: "Add a comment...",
+                        name: "comment",
+                        type: "textarea"
+                    }
+                ]}
+                validation={validateInviteData}
+                onSubmit={handleSubmit}
+                buttonText="comment"
+            />
         </div>
     );
 

--- a/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
+++ b/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
@@ -4,7 +4,7 @@ import {
     Button
 } from "react-bulma-components";
 
-import { getDashboardAction as gda, useStaff, useDashboardDispatch, useStaffByRole } from "pages/Dashboard/store";
+import { getDashboardAction as gda, useDashboardDispatch, useStaffByRole } from "pages/Dashboard/store";
 import Form, { createValidator } from "components/Form";
 import { ADD_STUDENT, ADD_STUDENTS, UPDATE_STUDENT } from "pages/Dashboard/store/actionsNames";
 import { getPriorityLevel } from "pages/Dashboard/utils/student";
@@ -84,7 +84,7 @@ export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
             name: "assignedTo",
             type: "select",
             options: staffOptionsList,
-            value: studentValue.assignedTo
+            value: studentValue.assignedTo || ""
         }
     ];
 

--- a/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
+++ b/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
@@ -67,11 +67,15 @@ export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
                 light: true,
                 size: "large"
             },
-            onMap: field => ({
+            /**
+             * Allows updates to be applied to input configurations using the live input value.
+             */
+            onMap: ({value,inputProps,...field}) => ({
                 ...field,
+                value,
                 inputProps: {
-                    ...field.inputProps,
-                    color: getPriorityLevel( field.value ).color,
+                    ...inputProps,
+                    color: getPriorityLevel( value ).color,
                 }
             })
         },

--- a/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
+++ b/client/src/pages/Dashboard/components/StudentModal/components/SettingsForm.js
@@ -7,7 +7,7 @@ import {
 import { getDashboardAction as gda, useStaff, useDashboardDispatch, useStaffByRole } from "pages/Dashboard/store";
 import Form, { createValidator } from "components/Form";
 import { ADD_STUDENT, ADD_STUDENTS, UPDATE_STUDENT } from "pages/Dashboard/store/actionsNames";
-import { usePriorityLevel } from "pages/Dashboard/utils/student";
+import { getPriorityLevel } from "pages/Dashboard/utils/student";
 import api from "utils/api";
 import { useSocket } from "utils/socket.io";
 
@@ -24,10 +24,8 @@ export const getStaffOptionsList = staff => [ { value: "", label: "Unassigned" }
 
 export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
 
-    const [ studentState, setStudentState ] = useState( student );
     const { ta } = useStaffByRole();
     const [ staffOptionsList, setStaffOptionsList ] = useState([]);
-    const priorityLevel = usePriorityLevel( studentState.priorityLevel );
 
     useEffect(() => {
 
@@ -35,16 +33,7 @@ export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
 
     }, [ ta, setStaffOptionsList ]);
 
-    useEffect(() => {
-
-        setStudentState( student || {} );
-
-    }, [ student, setStudentState ]);
-
-    const handleInputUpdate = ( { target: { name, value } } ) => {
-        // console.log();
-        setStudentState( { ...studentState, [name]: value } )
-    };
+    const studentValue = student || {};
 
     const fields = [
         (
@@ -55,8 +44,7 @@ export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
                 placeholder: "Separate students names by comma or line break (one student per line)",
                 name: "name",
                 type: "textarea",
-                value: studentState.name,
-                onChange: handleInputUpdate
+                value: studentValue.name,
             }
 
             : {
@@ -64,67 +52,58 @@ export const useStudentSettingsFormFields = ( student, isBulkCreate ) => {
                 placeholder: "Student Name",
                 name: "name",
                 type: "text",
-                value: studentState.name,
-                onChange: handleInputUpdate
+                value: studentValue.name,
             }
         ),
         {
             label: "Priority (At Risk Factor)",
             name: "priorityLevel",
             type: "range",
-            value: studentState.priorityLevel,
-            onChange: handleInputUpdate,
+            value: studentValue.priorityLevel,
             inputProps: {
                 min: 1,
                 max: 10,
                 step: 1,
-                color: priorityLevel ? priorityLevel.color : null,
                 light: true,
                 size: "large"
-            }
+            },
+            onMap: field => ({
+                ...field,
+                inputProps: {
+                    ...field.inputProps,
+                    color: getPriorityLevel( field.value ).color,
+                }
+            })
         },
         {
             label: "Staff Assignment",
             name: "assignedTo",
             type: "select",
             options: staffOptionsList,
-            value: studentState.assignedTo,
-            onChange: handleInputUpdate
+            value: studentValue.assignedTo
         }
     ];
 
     // Student form fields configuration.
-    return [
-        fields,
-        studentState
-    ];
+    return fields;
     
 }
 
 const SettingsForm = ({ roomId, student, afterSubmit, isBulkCreate }) => {
 
     const dispatch = useDashboardDispatch();
-    const [ errors, setErrors ] = useState( {} );
-    const [ fields, values ] = useStudentSettingsFormFields( student, isBulkCreate );
+    const fields = useStudentSettingsFormFields( student, isBulkCreate );
     const { _id } = student;
     const socket = useSocket();
 
-    const handleSubmit = async (e) => {
-
-        e.preventDefault();
-
-        const [ data, errors, hasErrors ] = validateStudentData(values);
-
-        if( hasErrors ) {
-            setErrors( errors );
-            return
-        }
+    const handleSubmit = async (data, setErrors) => {
 
         try {
 
             if( _id ) {
 
                 const dispatchData = gda( UPDATE_STUDENT, { _id, ...data } );
+
                 dispatch(dispatchData);
 
                 await api.updateStudent( roomId, _id, data );
@@ -166,7 +145,13 @@ const SettingsForm = ({ roomId, student, afterSubmit, isBulkCreate }) => {
 
     const button = <Button color="primary" className="is-light has-shadow-light">{(_id ? "Save" : "Create") + " Student"}</Button>;
 
-    return <Form fields={fields} onSubmit={handleSubmit} button={button} errors={errors} />;
+    return <Form
+            fields={fields}
+            fieldValueSource={student._id}
+            validation={validateStudentData}
+            onSubmit={handleSubmit}
+            button={button}
+            />;
 
 }
 

--- a/client/src/pages/Dashboard/utils/student.js
+++ b/client/src/pages/Dashboard/utils/student.js
@@ -31,7 +31,7 @@ export const studentGroupings = [
     }
 ]
 
-export const usePriorityLevel = (level) => priorityLevels.find( priorityLevel => !priorityLevel.test || priorityLevel.test(level) );
+export const getPriorityLevel = (level) => priorityLevels.find( priorityLevel => !priorityLevel.test || priorityLevel.test(level) );
 
 export const useStudentGroupings = () => {
 

--- a/client/src/pages/Dashboard/views/Team/components/InviteModal.js
+++ b/client/src/pages/Dashboard/views/Team/components/InviteModal.js
@@ -47,36 +47,15 @@ export const InviteModalButton = ({ icon = "plus-circle", open, children }) => {
 const InviteModal = ( { show, onClose, onInviteCreated } ) => {
 
     const dispatch = useDashboardDispatch();
-    const { _id } = useClassroom();
-    const [ email, setEmail ] = useState("");
-    const [ errors, setErrors ] = useState({});
     const socket = useSocket();
 
-    const fields = [
-        {
-            label: "Email",
-            placeholder: "Provide an email to invite",
-            name: "email",
-            type: "text",
-            value: email,
-            onChange: e => setEmail(e.target.value)
-        }
-    ];
+    const { _id } = useClassroom();
 
-    const handleSubmit = async (e) => {
+    const handleSubmit = async ( data, setErrors ) => {
 
-        e.preventDefault();
+        console.log(data);
 
         try {
-
-            const [ data, errors, hasErrors ] = validateInviteData({ email });
-
-            if(hasErrors) {
-                setErrors(errors);
-                return
-            }
-
-            if(Object.keys(errors).length) setErrors({});
 
             const { data: invite } = await api.createInvite( _id, data );
 
@@ -91,7 +70,7 @@ const InviteModal = ( { show, onClose, onInviteCreated } ) => {
         } catch(err) {
 
             if( err.response && err.response.data ) setErrors(err.response.data);
-            console.log(err);
+            // console.log(err);
 
         }
 
@@ -107,7 +86,20 @@ const InviteModal = ( { show, onClose, onInviteCreated } ) => {
                 <Box className="py-5">
                     <Heading renderAs="h2">Invite TA</Heading>
                     <hr />
-                    <Form flat fields={fields} onSubmit={handleSubmit} errors={errors} buttonText="Send Invite" />
+                    <Form
+                        flat
+                        fields={[
+                            {
+                                label: "Email",
+                                placeholder: "Provide an email to invite",
+                                name: "email",
+                                type: "text",
+                            }
+                        ]}
+                        onSubmit={handleSubmit}
+                        validation={validateInviteData}
+                        buttonText="Send Invite"
+                    />
                 </Box>
             </Modal.Content>
         </Modal>

--- a/client/src/pages/Invite.js
+++ b/client/src/pages/Invite.js
@@ -32,57 +32,18 @@ const columnSizes = {
 
 const RegstrationContent = ({ token, email }) => {
 
-    const [ name, setName ] = useState("");
-    const [ password, setPassword ] = useState("");
-    const [ password2, setPassword2 ] = useState("");
-    const [ errors, setErrors ] = useState({});
     const login = useLogin();
 
-    const fields = [
-        {
-            label: "Name",
-            placeholder: "Your name",
-            name: "name",
-            type: "text",
-            value: name,
-            onChange: e => setName(e.target.value)
-        },
-        {
-            label: "Password",
-            placeholder: "Password",
-            onChange: e => setPassword(e.target.value),
-            value: password,
-            type:"password",
-            name: "password"
-        },
-        {
-            label: "Confirm Password",
-            placeholder: "Password",
-            onChange: e => setPassword2(e.target.value),
-            value: password2,
-            type:"password",
-            name: "password2"
-        }
-    ];
-
-    const handleSubmit = async e => {
-
-        e.preventDefault();
+    const handleSubmit = async ( data, setErrors ) => {
 
         try {
 
-            const [ data, errors, hasErrors ] = validateRegistrationData({ name, password, password2 });
-
-            if( hasErrors ) {
-                setErrors(errors);
-                return
-            }
-
-            if(Object.keys(errors).length) setErrors({});
-
             await api.registerInvite( token, data );
 
-            await login( { email, password } );
+            await login( {
+                email: email,
+                password: data.password
+            } );
 
         } catch(err) {
 
@@ -102,7 +63,32 @@ const RegstrationContent = ({ token, email }) => {
                 <Box>
                     <Heading renderAs="h2" className="has-text-dark">Create an account</Heading>
                     <hr />
-                    <Form flat fields={fields} errors={errors} buttonText="Join Classroom" onSubmit={handleSubmit} />
+                    <Form
+                        flat
+                        fields={[
+                            {
+                                label: "Name",
+                                placeholder: "Your name",
+                                name: "name",
+                                type: "text",
+                            },
+                            {
+                                label: "Password",
+                                placeholder: "Password",
+                                type:"password",
+                                name: "password"
+                            },
+                            {
+                                label: "Confirm Password",
+                                placeholder: "Password",
+                                type:"password",
+                                name: "password2"
+                            }
+                        ]}
+                        validation={validateRegistrationData}
+                        onSubmit={handleSubmit}
+                        buttonText="Join Classroom"
+                    />
                 </Box>
             </Column>
         </Columns>

--- a/client/src/pages/Register/components/RegisterForm.js
+++ b/client/src/pages/Register/components/RegisterForm.js
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 
 import api from "utils/api";
 import { useLogin, validateUserData, validateRegistrationData } from "utils/auth";
-import Form, { validateAll } from "components/Form";
+import Form from "components/Form";
 import { useHistory } from "react-router-dom";
 
 const RegisterForm = () => {
@@ -10,77 +10,17 @@ const RegisterForm = () => {
     const login = useLogin();
     const history = useHistory();
 
-    const [ code, setCode ] = useState("");
-    const [ name, setName ] = useState("");
-    const [ email, setEmail ] = useState("");
-    const [ password, setPassword ] = useState("");
-    const [ password2, setPassword2 ] = useState("");
-    const [ roomname, setRoomName ] = useState("");
-    const [ errors, setErrors ] = useState({});
-
-    const fields = [
-        {
-            label: "Registration Code",
-            onChange: (e) => setCode(e.target.value),
-            value: code,
-            type:"text",
-            name: "code"
-        },
-        {
-            label: "Classroom Name",
-            onChange: (e) => setRoomName(e.target.value),
-            value: roomname,
-            type:"text",
-            name: "roomname"
-        },
-        {
-            label: "Your Name",
-            onChange: (e) => setName(e.target.value),
-            value: name,
-            name: "name"
-        },
-        {
-            label: "Email",
-            onChange: (e) => setEmail(e.target.value),
-            value: email,
-            type:"email",
-            name: "email"
-        },
-        {
-            label: "Password",
-            onChange: (e) => setPassword(e.target.value),
-            value: password,
-            type:"password",
-            name: "password"
-        },
-        {
-            label: "Confirm Password",
-            onChange: (e) => setPassword2(e.target.value),
-            value: password2,
-            type:"password",
-            name: "password2"
-        }
-    ];
-
-    const handleSubmit = async (e) => {
-
-        e.preventDefault();
+    const handleSubmit = async (data, setErrors) => {
 
         try {
-
-            const [ data, errors, hasErrors ] = validateAll( { code, name, email, password, password2, roomname }, validateUserData, validateRegistrationData );
-
-            if( hasErrors ) {
-                setErrors(errors);
-                return
-            }
-
-            setErrors({});
 
             await api.register(data);
 
             // Auto Login after registration
-            await login( { email, password } );
+            await login( {
+                email: data.email,
+                password: data.password
+            } );
             
             history.push("/");
 
@@ -92,7 +32,43 @@ const RegisterForm = () => {
 
     }
 
-    return <Form flat fields={fields} errors={errors} buttonText="Sign Up" onSubmit={handleSubmit} />;
+    return <Form
+            flat
+            fields={[
+                {
+                    label: "Registration Code",
+                    type:"text",
+                    name: "code"
+                },
+                {
+                    label: "Classroom Name",
+                    type:"text",
+                    name: "roomname"
+                },
+                {
+                    label: "Your Name",
+                    name: "name"
+                },
+                {
+                    label: "Email",
+                    type:"email",
+                    name: "email"
+                },
+                {
+                    label: "Password",
+                    type:"password",
+                    name: "password"
+                },
+                {
+                    label: "Confirm Password",
+                    type:"password",
+                    name: "password2"
+                }
+            ]}
+            validation={[validateUserData, validateRegistrationData]}
+            buttonText="Sign Up"
+            onSubmit={handleSubmit}
+            />;
 
 }
 


### PR DESCRIPTION
Overhauled a lot of the Form component so it could contain and abstract a lot of the repeat code/behavior that had started to crop up around every usage.

Part of this was a requirement to set up to needed order of operations to required to implement the processing state in a manner that didn't require a lot of extra code to be added with every single Form.

**MAJOR UPDATES**

- All field state is now created and managed within the Form component so each usage doesn't have to configure its own state.
- Validation process now occurs within the Form component
- The onSubmit function has been altered. It now accepts `data` and `setError` and is only called if provided validation passes.
- A `fieldValueSource` prop was added to the Form component which is used as a watcher to refresh field state values from outside the Form component.
- The Form component now manages an `isProcessing` state around it's internal submit process that will block duplicate submissions. The `isProcessing` state will `await` provide onSubmits to allow provided async behavior for the processing control from outside the component.
- Default submit buttons are put into Bulma's `is-loading` state