### PR TITLE
Fixed app type registration

### DIFF
--- a/app/config/apps/register.js
+++ b/app/config/apps/register.js
@@ -42,8 +42,10 @@ const registerAppTypes = async () => {
     for( let i = 0; i < toRegister.length; i++ ) {
 
         await appTypeCtrl.createOne({
-            type: toRegister[i],
-            name: appTypes[toRegister[i]].name
+            data: {
+                type: toRegister[i],
+                name: appTypes[toRegister[i]].name
+            }
         });
 
     }


### PR DESCRIPTION
Fixed issue with the app type registration. `appTypeCtrl.createOne` was not being called correctly.