### PR TITLE
Package updates

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1211,40 +1211,40 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.34.tgz",
-      "integrity": "sha512-0KNN0nc5eIzaJxlv43QcDmTkDY1CqeN6J7OCGSs+fwGPdtv0yOQqRjieopBCmw+yd7uD3N2HeNL3Zm5isDleLg==",
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.34"
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
       }
     },
     "@fortawesome/free-brands-svg-icons": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.2.tgz",
-      "integrity": "sha512-YPlVjE1cEO+OJ9I9ay3TQ3I88+XkxMTYwnnddqAboxLhPNGncsHV0DjWOVLCyuAY66yPfyndWwVn4v7vuqsO1g==",
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-1hirPcbjj72ZJtFvdnXGPbAbpn3Ox6mH3g5STbANFp3vGSiE5u5ingAKV06mK6ZVqNYxUPlh4DlTnaIvLtF2kw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.34"
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
       }
     },
     "@fortawesome/free-regular-svg-icons": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.2.tgz",
-      "integrity": "sha512-Uv5NQCYjyisNVTu/1Xjs+z8vwQjbfT6hiqYvQNfF0n8qdgfWLM581bAfVMQ3BCs1SPy+eEUKNcGkK4n0FihFHg==",
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-q4/p8Xehy9qiVTdDWHL4Z+o5PCLRChePGZRTXkl+/Z7erDVL8VcZUuqzJjs6gUz6czss4VIPBRdCz6wP37/zMQ==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.34"
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.2.tgz",
-      "integrity": "sha512-ZfCU+QjaFsdNZmOGmfqEWhzI3JOe37x5dF4kz9GeXvKn/sTxhqMtZ7mh3lBf76SvcYY5/GKFuyG7p1r4iWMQqw==",
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.34"
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
       }
     },
     "@fortawesome/react-fontawesome": {
@@ -5595,9 +5595,9 @@
       }
     },
     "engine.io-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.1.tgz",
-      "integrity": "sha512-iYasV/EttP/2pLrdowe9G3zwlNIFhwny8VSIh+vPlMnYZqSzLsTzSLa9hFy015OrH1s4fzoYxeHjVkO8hSFKwg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-5.0.1.tgz",
+      "integrity": "sha512-CQtGN3YwfvbxVwpPugcsHe5rHT4KgT49CEcQppNtu9N7WxbPN0MAG27lGaem7bvtCFtGNLSL+GEqXsFSz36jTg==",
       "requires": {
         "base64-arraybuffer": "0.1.4",
         "component-emitter": "~1.3.0",
@@ -5607,15 +5607,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
-        }
       }
     },
     "engine.io-parser": {
@@ -13320,9 +13312,9 @@
       }
     },
     "react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13549,13 +13541,13 @@
       }
     },
     "react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-error-overlay": {
@@ -14459,9 +14451,9 @@
       }
     },
     "scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -14868,15 +14860,15 @@
       }
     },
     "socket.io-client": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-3.1.1.tgz",
-      "integrity": "sha512-BLgIuCjI7Sf3mDHunKddX9zKR/pbkP7IACM3sJS3jha+zJ6/pGKRV6Fz5XSBHCfUs9YzT8kYIqNwOOuFNLtnYA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.0.1.tgz",
+      "integrity": "sha512-6AkaEG5zrVuSVW294cH1chioag9i1OqnCYjKwTc3EBGXbnyb98Lw7yMa40ifLjFj3y6fsFKsd0llbUZUCRf3Qw==",
       "requires": {
         "@types/component-emitter": "^1.2.10",
         "backo2": "~1.0.2",
         "component-emitter": "~1.3.0",
         "debug": "~4.3.1",
-        "engine.io-client": "~4.1.0",
+        "engine.io-client": "~5.0.0",
         "parseuri": "0.0.6",
         "socket.io-parser": "~4.0.4"
       }
@@ -17554,11 +17546,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xtend": {
       "version": "4.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -5,10 +5,10 @@
   "proxy": "http://localhost:3001/",
   "ws": true,
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.34",
-    "@fortawesome/free-brands-svg-icons": "^5.15.2",
-    "@fortawesome/free-regular-svg-icons": "^5.15.2",
-    "@fortawesome/free-solid-svg-icons": "^5.15.2",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-brands-svg-icons": "^5.15.3",
+    "@fortawesome/free-regular-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "axios": "^0.21.1",
     "bulma": "^0.9.2",
@@ -16,13 +16,13 @@
     "jwt-decode": "^3.1.2",
     "luxon": "^1.26.0",
     "node-sass": "^5.0.0",
-    "react": "^17.0.1",
+    "react": "^17.0.2",
     "react-bulma-components": "^3.4.0",
     "react-copy-to-clipboard": "^5.0.3",
-    "react-dom": "^17.0.1",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
-    "socket.io-client": "^3.1.1"
+    "socket.io-client": "^4.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crsm",
-  "version": "0.5.8",
+  "version": "0.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -194,9 +194,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.13.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.7.tgz",
-      "integrity": "sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -425,9 +425,9 @@
       "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
     },
     "@types/mongodb": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.8.tgz",
-      "integrity": "sha512-8qNbL5/GFrljXc/QijcuQcUMYZ1iWNcqnJ6tneROwbfU0LsAjQ9bmq3aHi5lWXM4cyBPd2F/n9INAk/pZZttHw==",
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
+      "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -517,19 +517,18 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.11.0"
+        "type-fest": "^0.21.3"
       }
     },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -783,9 +782,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -857,16 +856,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
-      "integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -984,7 +983,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1059,9 +1057,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concurrently": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.0.tgz",
-      "integrity": "sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.1.tgz",
+      "integrity": "sha512-YCF/Wf31a910hXu7eGN9/SyHKD/usw3Shw4IPYuqIsxxC39v92engYlIlOs/zXnBJtX/6aVuhgzfhZeGJkhU4w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -1252,9 +1250,9 @@
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "date-fns": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.17.0.tgz",
-      "integrity": "sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==",
       "dev": true
     },
     "debug": {
@@ -1442,9 +1440,9 @@
       }
     },
     "engine.io": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.0.0.tgz",
+      "integrity": "sha512-BATIdDV3H1SrE9/u2BAotvsmjJg0t1P4+vGedImSs1lkFAtQdvk4Ev1y4LDiPF7BPWgXWEG+NDY+nLvW3UrMWw==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
@@ -1598,9 +1596,9 @@
       }
     },
     "fastest-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastest-validator/-/fastest-validator-1.10.0.tgz",
-      "integrity": "sha512-qNspEkJiwD2OHRrZukvAIxBQkOJjFTdlQ2NYNn2Gv4hudhYL37MTqe5hsdM3hrYonZGzbZADSddcMhYN1slBuA=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastest-validator/-/fastest-validator-1.10.1.tgz",
+      "integrity": "sha512-nhQP8JI16Ltml3kFKCEckKzxmPDYXZw0r+zF83Kf5qcJmA2Hoo4ORSo+SduxNiIbKpSS0i+3mV/UPhu8Po7Qkw=="
     },
     "figures": {
       "version": "3.2.0",
@@ -1642,6 +1640,16 @@
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "flat": {
@@ -1968,9 +1976,9 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.0.0.tgz",
+      "integrity": "sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -1979,21 +1987,15 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
+        "rxjs": "^6.6.6",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2028,42 +2030,25 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
+            "tslib": "^1.9.0"
           }
         },
         "supports-color": {
@@ -2428,9 +2413,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
     "jwa": {
@@ -2488,6 +2473,15 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -2715,86 +2709,62 @@
       "dev": true
     },
     "mjml": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.8.1.tgz",
-      "integrity": "sha512-jdKABiLBA1IJ0qTA5QVVsi/NN5GFtdvC1lxwdxrYV6J7dcJW7Z07j3r/GmJyOc2cznCFpJFKzfYV4Z6OZS4iyw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.9.0.tgz",
+      "integrity": "sha512-34oQtWxbNEwGBCAESAYRtmKdgicIYBWjfB4NY2OzufQ4JxK5BdpvWWVAoG5moty/cxKuhgSh7Q9DSaSWrdmvRA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
-        "mjml-accordion": "4.8.1",
-        "mjml-body": "4.8.1",
-        "mjml-button": "4.8.1",
-        "mjml-carousel": "4.8.1",
-        "mjml-cli": "4.8.1",
-        "mjml-column": "4.8.1",
-        "mjml-core": "4.8.1",
-        "mjml-divider": "4.8.1",
-        "mjml-group": "4.8.1",
-        "mjml-head": "4.8.1",
-        "mjml-head-attributes": "4.8.1",
-        "mjml-head-breakpoint": "4.8.1",
-        "mjml-head-font": "4.8.1",
-        "mjml-head-html-attributes": "4.8.1",
-        "mjml-head-preview": "4.8.1",
-        "mjml-head-style": "4.8.1",
-        "mjml-head-title": "4.8.1",
-        "mjml-hero": "4.8.1",
-        "mjml-image": "4.8.1",
-        "mjml-migrate": "4.8.1",
-        "mjml-navbar": "4.8.1",
-        "mjml-raw": "4.8.1",
-        "mjml-section": "4.8.1",
-        "mjml-social": "4.8.1",
-        "mjml-spacer": "4.8.1",
-        "mjml-table": "4.8.1",
-        "mjml-text": "4.8.1",
-        "mjml-validator": "4.8.1",
-        "mjml-wrapper": "4.8.1"
+        "mjml-cli": "4.9.0",
+        "mjml-core": "4.9.0",
+        "mjml-migrate": "4.9.0",
+        "mjml-preset-core": "4.9.0",
+        "mjml-validator": "4.9.0"
       }
     },
     "mjml-accordion": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.8.1.tgz",
-      "integrity": "sha512-VviMSaWlHkiTt0bVSdaIeDQjkApAjJR2whEhVvQmEjpu5gJdUS2Po6dQHrd/0ub8gCVMzVq62UKJdPM0fTBlMw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.9.0.tgz",
+      "integrity": "sha512-wj8Z2Nm8brZQzVHE6Uds7dMjBq/cjyC6UhPbaG2QpkfvTTZ7fxEIVS2LJgeAkuqHjnzQJNvQU8cFWRiB2Uw5zQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-body": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.8.1.tgz",
-      "integrity": "sha512-L8DjOveb1GsxSAOye7CyeTsqBQ13DBQCuRVz9dXF1pjycawgK3eBvMHhlXAkCcuNlRUuH0/jI04f2whkYTYOZg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.9.0.tgz",
+      "integrity": "sha512-1CvOpMchVwauVH0PEqd2yfPQAxXJ2E1OEPFItQfs2M1rFl0RHdN1TvkJmSig05WKGirTn/5AMZlKZSnl3cWTZw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-button": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.8.1.tgz",
-      "integrity": "sha512-qiPtRQkC1/4QjHPTA8NvpVgK8jRIevEo2pgxw8gDsstkWSnV/TxrzQxQ6iWaWI7gGD3ZOQUMvVTpUeuPAJGssw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.9.0.tgz",
+      "integrity": "sha512-7kNE77NF3qKsE5a+ZSvpNaE8mrariokISwFsfxDTL3+GNuPas3dGIFCOYkMYXRu8wCWoNNh4eTd4GmnLieKGaA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-carousel": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.8.1.tgz",
-      "integrity": "sha512-YlYy6sQuhi1Q889WW9OwQp9qZvb0mR7M/9rnCgRzI5SFd9dICwafEz5hKHTfy4o/d1CWnKF5Gp/ovg/Ci6pm4A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.9.0.tgz",
+      "integrity": "sha512-Xgo5is2dpSdfeaPZ91mJ34jBTDCS4hLvc6X6VGcV9oUUvpO7ttDuKw6hMKevS123L9Xyl7NYn6e+5ZtR/JElIQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-cli": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.8.1.tgz",
-      "integrity": "sha512-Yb/Ykwin4XLpX9uonFW1GK7aMc3CBUDtcbPsVMC/p9g3U1rXi/Bp4MFpya8WoHT9D4N97gGJPEQ7ndCrzMrgNQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.9.0.tgz",
+      "integrity": "sha512-FOkmYvFYMn17wON3i3Sm86SjcLwqXFEfZR2lOc/5zvyEN3JpUna/8v2Tt9EeP+S38sWyDarVlKtilJnKKm/7Lg==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "chokidar": "^3.0.0",
@@ -2802,107 +2772,27 @@
         "html-minifier": "^4.0.0",
         "js-beautify": "^1.6.14",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1",
-        "mjml-migrate": "4.8.1",
-        "mjml-parser-xml": "4.8.1",
-        "mjml-validator": "4.8.1",
+        "mjml-core": "4.9.0",
+        "mjml-migrate": "4.9.0",
+        "mjml-parser-xml": "4.9.0",
+        "mjml-validator": "4.9.0",
         "yargs": "^16.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.6",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-          "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA=="
-        }
       }
     },
     "mjml-column": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.8.1.tgz",
-      "integrity": "sha512-8UlYNtBgcEylnFAA+il+LEeuP8sf91ml7v9yV9GWVZpdS9o2eQI1LHtmlEZ6+PDVG9CYpmTm1XZ0YWqBsVVtBg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.9.0.tgz",
+      "integrity": "sha512-lFkYgxx8aRPChEV8hBpgOXAtQFw6YT9WuwbMfvNnUz0R9aIE7rvWLxMaHXsslla4YZz+LB3amPJgeqlDZ9HNjg==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-core": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.8.1.tgz",
-      "integrity": "sha512-CXKzgu3BjgtSfNKDeihK75fLOhhimEZK4eU5ZCgVgtD5S3txfyA+IbRPKikcj5V/vF1Zxfipr3P4SMnVAIi1vA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.9.0.tgz",
+      "integrity": "sha512-89mMFH2+CwMXhEMgy1PT/KrqjOBcl4yezdZk/I3JezIYhv39kaa2Q0yt2uOmdDwxGIVkLAtA32Kug/a1K+zbQQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "cheerio": "1.0.0-rc.3",
@@ -2911,238 +2801,158 @@
         "js-beautify": "^1.6.14",
         "juice": "^7.0.0",
         "lodash": "^4.17.15",
-        "mjml-migrate": "4.8.1",
-        "mjml-parser-xml": "4.8.1",
-        "mjml-validator": "4.8.1"
+        "mjml-migrate": "4.9.0",
+        "mjml-parser-xml": "4.9.0",
+        "mjml-validator": "4.9.0"
       }
     },
     "mjml-divider": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.8.1.tgz",
-      "integrity": "sha512-kaDHd++6qfOp79dm9k/3o4uMLvhSMy01HjWO5+HCYGv9V4ZLHRHmz8MJVz9plpRByRsOV0gw88vXDNiGVqX6Eg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.9.0.tgz",
+      "integrity": "sha512-DYsFunfmhtlUQ9Fkf2ZZGkMdWALStcZZcFJBLQMpz07UzpVeWgvlH1o2MPn81rfyDpwMBW6PgwoGlZ7tcpAP8Q==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-group": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.8.1.tgz",
-      "integrity": "sha512-839DbzEg9GzXgwjXSJZFcx3k18DiklAHCnhpy/fbH5C1IbFU0W5I3V105p2a9jeXVIvrRiDw4pCjoPSJsNu5lQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.9.0.tgz",
+      "integrity": "sha512-/CH6gQ1qzaG/3P5pKttSGRZaY3FB8pEsyiUNDIV8yEqgu0AYYLT7LOFyIEqC3+BYYLavecnyelyEKbiM0+qZaA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.8.1.tgz",
-      "integrity": "sha512-6UeXCXFN/+8ehwE20weE68Kx1kaWySdffqPm2zjvDdOWQPEAO9tx3FnJk3MuR0kZ6vcvuM0KXYLXlC5rJS02Dg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.9.0.tgz",
+      "integrity": "sha512-CA8iJBp8DjI20j2quJbvB55h2tM+rVaYcB2rPykLq/kQuNEdgxEtIEuHWr1QMteBf0smXfSK/UDw4/vp2Ja0Cw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-attributes": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.8.1.tgz",
-      "integrity": "sha512-PthSJB+znbNfOZ5DHFiuoY9hG97rgmcKzq0Htn6YQuzVFEtvrKXf7cj57M23RkFq2Gcyvn/8VJ98F6kG1Pfq7A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.9.0.tgz",
+      "integrity": "sha512-QCCkcYIGDxdfBeI4Oy5jPHvmUCPmhTA6Fy4o3kLLpv+MoG9aDdJIH7SGrQoy2BoQp/MYoMPxau3miY10P/Ozwg==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-breakpoint": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.8.1.tgz",
-      "integrity": "sha512-ABL6L5GKRE3wWY5YOZEHDp5MQN1oV9srTR13Ohe/IC3MHaLv78T98E8iEBYr51RnVlfMkhfGNJF8vn6C8EXIFQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.9.0.tgz",
+      "integrity": "sha512-GXyIe2QBNll1DX1dPPOrww+wW/GqaV8GkBmzfyL3OCN2k5N1eYTx6FP9VPkJi43EDvRALgQJK7sy8CeWWAnVvA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-font": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.8.1.tgz",
-      "integrity": "sha512-Gm4QOKQOE87D6pCor1IqBT76PPd0fhtSXWpceacf9oS8QtZtI1VjNuP7TiEk+T5DZo5mM+0zKuhrW7EUPfku3w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.9.0.tgz",
+      "integrity": "sha512-pqJcG0jpCYxsV8FjLrtbgCzU23z0kalwcxaOpulCXonSsfUNRtp68TVE2L1rNkcLrwhjIdlLoGHBAPLo47uQdg==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-html-attributes": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.8.1.tgz",
-      "integrity": "sha512-WNZnF0+2Q3aBAYXvthiOHg4URPxUKdTSNmCsrTajqDrP/1A0lin5uLrKc/BGf2MiiBtSvz2kUYbkEBPn7qvSBA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.9.0.tgz",
+      "integrity": "sha512-NSLEiq8cs+8AYdZrbIxsNTWqUEkRMxtAD294YsGvM5NsuzAJOGqJ/BT+aZbm3qiMKeWhaj9OPiph6VV/k+IUzw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-preview": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.8.1.tgz",
-      "integrity": "sha512-7u9Y7p9DpmGedKMAzvRPl5u3vazi7AWj1iNV/cHyt6couWlszrLGiG2L9dxr58zSfsxvAyGLH+dVcx/qRsQwZA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.9.0.tgz",
+      "integrity": "sha512-ZiNJFyuMWbvUHJVszPa9EkadeapeWoQdTYjqBio+QOQYcwIGmrsIu0P2ffaLqRUYZLubudF5+1eGGGKRy0cOAw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-style": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.8.1.tgz",
-      "integrity": "sha512-QeYHhSPzv3fV5vM1huFiERmLZ/UzJAxqSz/BJiqwZ0qawWLxVG6ku8VTwNQdiWKD4Wnsiijre41rwPttv4OiJQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.9.0.tgz",
+      "integrity": "sha512-t/aVMReqYMyXwzedMMCM/TLGboqkpRlbuHixOjG9AnNug1QuDnuAj0mE5sFVbbxz1bcuE+rGJ0Q69ynkNTW2rQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-head-title": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.8.1.tgz",
-      "integrity": "sha512-Nc49MlGxML4orDL9XKMnaZDHFSivGZnOTls/TH4nkZG+TLMzLf/6+f//Im1x8XiLKhWgETuGff7eFc1PadxVKg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.9.0.tgz",
+      "integrity": "sha512-+QxEtIWvgqOjbQNEvS3/IYTrVORpIVffpsEsoPlcgO7K0i6Q+Q7i/O2u3ViFfUW5y7p/tjO0P1TP6nQX+H5lQw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-hero": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.8.1.tgz",
-      "integrity": "sha512-LYe1mzNySN0M/ZHx8IMB5+v5MzKVHElujzywEFKnAFycWXPjRTvFUDp+PzWP55rbg5GILu4+pgD8ePZH02DHOQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.9.0.tgz",
+      "integrity": "sha512-yPpfn5uHL86oWlG0utcJ5SxHEmnsBK8n+SILhDSUbi8cLHWkloCrsuwGOYM9ebD1lcw09if9jPvXUZi0wNYHag==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-image": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.8.1.tgz",
-      "integrity": "sha512-3xHmUhdfoOVFzXkFV0bpq84ZGQgQrJbCVeArpz7DdwjjaEER7cYoleAMPtlgOlEyx1TwAJzClpIRO887MkV/qg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.9.0.tgz",
+      "integrity": "sha512-hKjW07e+K5pZBPGkC5EXYVEalrWA91+ut+X8guMZOie89XlT/pDDotXXZnocB2hmo75c2lEoMW/ygTbc+Xmv0g==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-migrate": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.8.1.tgz",
-      "integrity": "sha512-U8s9uzgjsOt9so+oqq9Dd9x/bZfkPva8euzF2RiN09wfUIKfglMblZyarsbaVTyFT3BOFKbJ091YcVBobsCJiQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.9.0.tgz",
+      "integrity": "sha512-rKqy9isx73tD85zcghuj1krIUHky0o/MuQEDOaStcaln6LlR9019tLTbgMefjBflcHNDL0BgMFzp/jdP35u13w==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "js-beautify": "^1.6.14",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1",
-        "mjml-parser-xml": "4.8.1",
+        "mjml-core": "4.9.0",
+        "mjml-parser-xml": "4.9.0",
         "yargs": "^16.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.6",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-          "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA=="
-        }
       }
     },
     "mjml-navbar": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.8.1.tgz",
-      "integrity": "sha512-6Y3ITpDYz9HytT69A59hk50/y1r7iOkGQL7PP2qltWAjj2eHxUpu0dsPfPvV0a2X6HB9DXOSPJSWdHNHowI/dQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.9.0.tgz",
+      "integrity": "sha512-hH+xo6rVfFVT+M/1nhnIyE6lmHHLoZrrdrfJwTx6xPV2mw05fbDFNNnfK2T+8PU9koYpU2RYo2ZahVa1LxYU0A==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-parser-xml": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.8.1.tgz",
-      "integrity": "sha512-kU9IpBVWfeDad/vuDpBt0okz9yRyvy+H6JRZqrUm+qDkzNQHEChnLl3U47FYj81SMuh0CVTGatCIi05pFC396g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.9.0.tgz",
+      "integrity": "sha512-YD9BMjr7l5B49czSj2OtLW5+1i53GgMnroIt84F+QUWUz9f6pyeK4cyUO/L5wKW+WiTVM3O0q142Bmq45PZvyA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "detect-node": "2.0.4",
@@ -3161,19 +2971,19 @@
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
               "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
               }
             }
           }
         },
         "domelementtype": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         },
         "domhandler": {
           "version": "3.3.0",
@@ -3184,21 +2994,21 @@
           }
         },
         "domutils": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+          "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
           "requires": {
             "dom-serializer": "^1.0.1",
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0"
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.1.0"
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
               "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
               }
             }
           }
@@ -3221,83 +3031,116 @@
         }
       }
     },
+    "mjml-preset-core": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-4.9.0.tgz",
+      "integrity": "sha512-sNWt6sffvzgvBgrZA1LclxAV/YuWy2UZIBuGbTjKVhYil1EfrH8SeZClyIBcVW42vx7qDRVnPYrV7w88CBRzOQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "mjml-accordion": "4.9.0",
+        "mjml-body": "4.9.0",
+        "mjml-button": "4.9.0",
+        "mjml-carousel": "4.9.0",
+        "mjml-column": "4.9.0",
+        "mjml-divider": "4.9.0",
+        "mjml-group": "4.9.0",
+        "mjml-head": "4.9.0",
+        "mjml-head-attributes": "4.9.0",
+        "mjml-head-breakpoint": "4.9.0",
+        "mjml-head-font": "4.9.0",
+        "mjml-head-html-attributes": "4.9.0",
+        "mjml-head-preview": "4.9.0",
+        "mjml-head-style": "4.9.0",
+        "mjml-head-title": "4.9.0",
+        "mjml-hero": "4.9.0",
+        "mjml-image": "4.9.0",
+        "mjml-navbar": "4.9.0",
+        "mjml-raw": "4.9.0",
+        "mjml-section": "4.9.0",
+        "mjml-social": "4.9.0",
+        "mjml-spacer": "4.9.0",
+        "mjml-table": "4.9.0",
+        "mjml-text": "4.9.0",
+        "mjml-wrapper": "4.9.0"
+      }
+    },
     "mjml-raw": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.8.1.tgz",
-      "integrity": "sha512-NIwHVcFDCOuFHB9dY1fLyRSRTuq//FcYPyorJrEt9TTEY16KznjRyJvJohPbF7bcLoYiqBUDFSRtI7qJFTFapg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.9.0.tgz",
+      "integrity": "sha512-gKNEqpPDPYPdSoHy+/JdUeclnuHEsF8SWVgMkthc3581T2qefYZAORU7Kj1BZWTIsxObcGYfWJu6kQWKVpj8PA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-section": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.8.1.tgz",
-      "integrity": "sha512-cksu5rVBioDjNZyyWBwV2oW+HdUGrESMQSACrJCgeQFTbkJ7GdiCqsGOGTZN4OoM8DvHAizXzOXHZY9GPC4M8g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.9.0.tgz",
+      "integrity": "sha512-9SdCf+Jf2ezhA6y/zEjvPvAyyccyRwpqusI2M83guM40tFzevknjMqzM1MnHAebQiXwS4+3xfoTHas5GgJhFqA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-social": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.8.1.tgz",
-      "integrity": "sha512-YU0eJg0BnqfV1JzHONWabnZ8c1xJATezVXe1z0xMhXpe/lPPWRjqv97Sf06h2NoK8z9F6PvifHBVv6/kU0HU6g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.9.0.tgz",
+      "integrity": "sha512-CxbUP5Kv7Mzag5wf1js31RaZCPeQMV7JgeYaFAFMNp8f3PF6p33nS4FMFQpyGsoYKUSTkRCaSDFnjHR4MMfibw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-spacer": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.8.1.tgz",
-      "integrity": "sha512-pMvL2YK0Phb7m78cwipWb+OmvP1TT1spsYDtC1qFuK46vkdOpesGS9dhPMG5iApbaKOcdmoIENtsD01agIzjjw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.9.0.tgz",
+      "integrity": "sha512-UXZEnvxjqajXXRkYrV6a2TN1PBKKkhb8DM4zvlgwZrllh/fEimiu1GWZm2AfCvp1Yax+uuDG3dXr37xVk0B+Hg==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-table": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.8.1.tgz",
-      "integrity": "sha512-aXOThuC9d3wcnuigefqPcUTticSKul9+ElFKDiX5SEGmXbr3g5Mp3TaM9218GaXfyGJNFEe4eWfiwqjeRv8Fmw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.9.0.tgz",
+      "integrity": "sha512-cFKO5tQGxpJCzK1W5aDjkY0BVXfFEVG7akNp3bVeHO0hjdR2Gdvd/hVJPOqhG1aL4PmqJuTZhrMchTTTbifezA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-text": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.8.1.tgz",
-      "integrity": "sha512-wA+/pMEmJqDnSR45w6jon/f2HGnLddcc19DNo77EfW8yw6KVyjvDdRs5y6L0S7Ri265AsgzvG7hNbJ31AwjtJw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.9.0.tgz",
+      "integrity": "sha512-734JDf1uDiEn0q9fAkW09FHGFBteLYyBGCd8xK5vqenbO0dtEp/j1vjKaw9yMUd6K4MZp4+r7e1N3DsZto4uSQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1"
+        "mjml-core": "4.9.0"
       }
     },
     "mjml-validator": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.8.1.tgz",
-      "integrity": "sha512-5qykc1kLILqj89Zqij6SsuKHG/jp5mjJfZWFpC8sEKIPVxBKBduz3BNSp5KABue1wW17swaXyMFhCjiFD+QRrg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.9.0.tgz",
+      "integrity": "sha512-ta6ipn9QiIFzsLq6yT+CIsadB/GHVTbRYQ7AIBowlrHSREmip4pxPDk6WdaQtjFfG9XD4GQwbJoUbKCERFDg6w==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       }
     },
     "mjml-wrapper": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.8.1.tgz",
-      "integrity": "sha512-PgOg6sEW/bXOnvMt5L2KuJCdlsOclw+GqH9Cf3gVHgw2P+7OfLIp6p+gByYTwjc4JAoUz0mfcCWdZ9HRMSCcYQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.9.0.tgz",
+      "integrity": "sha512-fhaa/KIJKEc/SLeYCKF6D8/iQAEM8OFGbna1CdflxbS6Sn3N9wWprWypZN5kbc9zXRR0+G+yI7b19mTYs4Iv0g==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "lodash": "^4.17.15",
-        "mjml-core": "4.8.1",
-        "mjml-section": "4.8.1"
+        "mjml-core": "4.9.0",
+        "mjml-section": "4.9.0"
       }
     },
     "mkdirp": {
@@ -3306,9 +3149,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
+      "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -3338,21 +3181,6 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3374,32 +3202,6 @@
             "normalize-path": "~3.0.0",
             "readdirp": "~3.5.0"
           }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
         },
         "debug": {
           "version": "4.3.1",
@@ -3424,28 +3226,12 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
         "fsevents": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
           "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
         },
         "js-yaml": {
           "version": "4.0.0",
@@ -3456,68 +3242,17 @@
             "argparse": "^2.0.1"
           }
         },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
         "strip-json-comments": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         },
         "which": {
           "version": "2.0.2",
@@ -3526,38 +3261,6 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
@@ -3569,9 +3272,9 @@
       }
     },
     "mongodb": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
-      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.5.tgz",
+      "integrity": "sha512-mQlYKw1iGbvJJejcPuyTaytq0xxlYbIoVDm2FODR+OHxyEiMR021vc32bTvamgBjCswsD54XIRwhg3yBaWqJjg==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -3582,17 +3285,17 @@
       }
     },
     "mongoose": {
-      "version": "5.11.18",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.18.tgz",
-      "integrity": "sha512-RsrPR9nhkXZbO3ml0DcmdbfeMvFNhgFrP81S6o1P+lFnDTNEKYnGNRCIL+ojD69wj7H5jJaAdZ0SJ5IlKxCHqw==",
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.3.tgz",
+      "integrity": "sha512-frsSR9yeldaRpSUeTegXCSB0Tu5UGq8sHuHBuEV31Jk3COyxlKFQPL7UsdMhxPUCmk74FpOYSmNwxhWBEqgzQg==",
       "requires": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",
         "kareem": "2.3.2",
-        "mongodb": "3.6.4",
+        "mongodb": "3.6.5",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.8.3",
-        "mquery": "3.2.4",
+        "mquery": "3.2.5",
         "ms": "2.1.2",
         "regexp-clone": "1.0.0",
         "safe-buffer": "5.2.1",
@@ -3623,9 +3326,9 @@
       "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
     },
     "mquery": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.4.tgz",
-      "integrity": "sha512-uOLpp7iRX0BV1Uu6YpsqJ5b42LwYnmu0WeF/f8qgD/On3g0XDaQM6pfn0m6UxO6SM8DioZ9Bk6xxbWIGHm2zHg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
+      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -3719,9 +3422,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.18",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.18.tgz",
-      "integrity": "sha512-ht9cXxQ+lTC+t00vkSIpKHIyM4aXIsQ1tcbQCn5IOnxYHi81W2XOaU66EQBFFpbtzLEBTC94gmkbD4mGZQzVpA=="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.5.0.tgz",
+      "integrity": "sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw=="
     },
     "nodemon": {
       "version": "2.0.7",
@@ -4042,6 +3745,26 @@
         "p-try": "^2.0.0"
       }
     },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
+    },
     "p-map": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -4144,6 +3867,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4662,16 +4391,16 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -4709,26 +4438,21 @@
       "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
     },
     "socket.io": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.1.tgz",
-      "integrity": "sha512-7cBWdsDC7bbyEF6WbBqffjizc/H4YF1wLdZoOzuYfo2uMNSFjJKuQ36t0H40o9B20DO6p+mSytEd92oP4S15bA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.0.1.tgz",
+      "integrity": "sha512-g8eZB9lV0f4X4gndG0k7YZAywOg1VxYgCUspS4V+sDqsgI/duqd0AW84pKkbGj/wQwxrqrEq+VZrspRfTbHTAQ==",
       "requires": {
         "@types/cookie": "^0.4.0",
         "@types/cors": "^2.8.8",
-        "@types/node": "^14.14.10",
+        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.1",
-        "engine.io": "~4.1.0",
-        "socket.io-adapter": "~2.1.0",
+        "engine.io": "~5.0.0",
+        "socket.io-adapter": "~2.2.0",
         "socket.io-parser": "~4.0.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.14.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -4745,9 +4469,9 @@
       }
     },
     "socket.io-adapter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.2.0.tgz",
+      "integrity": "sha512-rG49L+FwaVEwuAdeBRq49M97YI3ElVabJPzvHT9S6a2CWhDKnjSFasvwAwSYPRhQzfn4NtDIbCaGYgOCOU/rlg=="
     },
     "socket.io-parser": {
       "version": "4.0.4",
@@ -4926,7 +4650,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -5044,9 +4767,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
     "type-is": {
@@ -5068,9 +4791,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w=="
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
+      "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig=="
     },
     "undefsafe": {
       "version": "2.0.3",
@@ -5241,19 +4964,19 @@
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
               "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
               }
             }
           }
         },
         "domelementtype": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         },
         "domhandler": {
           "version": "3.3.0",
@@ -5264,21 +4987,21 @@
           }
         },
         "domutils": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+          "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
           "requires": {
             "dom-serializer": "^1.0.1",
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0"
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.1.0"
           },
           "dependencies": {
             "domhandler": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-              "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+              "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
               "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
               }
             }
           }
@@ -5375,7 +5098,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5386,7 +5108,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -5395,7 +5116,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -5403,8 +5123,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },
@@ -5426,9 +5145,9 @@
       }
     },
     "ws": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -5437,10 +5156,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.2.tgz",
+      "integrity": "sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -5451,7 +5169,6 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -5463,18 +5180,16 @@
       },
       "dependencies": {
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-          "dev": true
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz",
+          "integrity": "sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ=="
         }
       }
     },
     "yargs-parser": {
-      "version": "20.2.6",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
-      "dev": true
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^4.3.0",
-    "concurrently": "^6.0.0",
-    "inquirer": "^7.3.3",
+    "chai": "^4.3.4",
+    "concurrently": "^6.0.1",
+    "inquirer": "^8.0.0",
     "link-module-alias": "^1.2.0",
-    "mocha": "^8.3.0",
+    "mocha": "^8.3.2",
     "nodemon": "^2.0.7",
     "nyc": "^15.1.0",
-    "sinon": "^9.2.4"
+    "sinon": "^10.0.0"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.4.2",
@@ -41,14 +41,14 @@
     "crypto": "^1.0.1",
     "dotenv": "^8.2.0",
     "express": "^4.16.3",
-    "fastest-validator": "^1.10.0",
+    "fastest-validator": "^1.10.1",
     "if-env": "^1.0.4",
     "jsonwebtoken": "^8.5.1",
-    "mjml": "^4.8.1",
-    "mongoose": "^5.11.18",
-    "nodemailer": "^6.4.18",
+    "mjml": "^4.9.0",
+    "mongoose": "^5.12.3",
+    "nodemailer": "^6.5.0",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
-    "socket.io": "^3.1.1"
+    "socket.io": "^4.0.1"
   }
 }


### PR DESCRIPTION
**Server**

- chai 4.3.0 -> 4.3.4
- concurrently 6.0.0 -> 6.0.1
- inquirer 7.3.3 -> 8.0.0
- mocha 8.3.0 -> 8.3.2
- sinon 9.2.4 -> 10.0.0
- fastest-validator 1.10.0 -> 1.10.1
- mjml 4.8.1 -> 4.9.0
- mongoose 5.11.18 -> 5.12.3
- nodemailer 6.4.18 -> 6.5.0
- socket.io 3.1.1 -> 4.0.1
- npm audit fix for y18n vulnerability

**Client**

- @fortawesome/fontawesome-svg-core 1.2.34 -> 1.2.35
- @fortawesome/free-brands-svg-icons 5.15.2 -> 5.15.3
- @fortawesome/free-regular-svg-icons 5.15.2 -> 5.15.3
- @fortawesome/free-solid-svg-icons 5.15.2 -> 5.15.3
- react 17.0.1 -> 17.0.2
- react-dom 17.0.1 -> 17.0.2
- socket.io-client 3.1.1 -> 4.0.1