### PR TITLE
Sub schema model coupling

### DIFF
--- a/app/controllers/definitions/FeedEntryController.js
+++ b/app/controllers/definitions/FeedEntryController.js
@@ -1,6 +1,4 @@
-
 const SubSchemaController = require("../types/SubSchemaController");
-const feedCtrl = require("../feed");
 
 /**
  * @param {FeedEntryController} ctrl 
@@ -44,7 +42,7 @@ class FeedEntryController extends SubSchemaController {
 
     constructor( action ) {
 
-        super( "item", feedCtrl, action );
+        super( "item", "feed", action );
 
         this.action = action;
 

--- a/app/controllers/definitions/StudentController.js
+++ b/app/controllers/definitions/StudentController.js
@@ -1,8 +1,6 @@
 const ObjectId = require("mongoose").Types.ObjectId;
 const SubSchemaController = require("../types/SubSchemaController");
 
-const roomCtrl = require("../room");
-
 /**
  * TYPE DEFINITION IMPORTS
  * @typedef {import("../types/SubSchemaController").CreateSubDocOptions} CreateSubDocOptions
@@ -39,7 +37,7 @@ class StudentController extends SubSchemaController {
 
     constructor() {
 
-        super( "student", roomCtrl );
+        super( "student", "room" );
 
     }
 

--- a/app/controllers/types/Controller.js
+++ b/app/controllers/types/Controller.js
@@ -1,3 +1,5 @@
+const library = require("./library");
+
 /**
  * @see https://ponyfoo.com/articles/binding-methods-to-class-instance-objects#proxies
  * 
@@ -28,8 +30,6 @@ const makeFnBindingMap = controller => {
     return proxy;
 
 }
-
-const library = new Map();
 
 class Controller {
 

--- a/app/controllers/types/SubSchemaController.js
+++ b/app/controllers/types/SubSchemaController.js
@@ -45,21 +45,29 @@ class SubSchemaController extends Controller {
     /** @type {string} */
     prop;
 
-    /** @type {SchemaController} */
-    ctrl;
+    /** @type {string} */
+    modelCtrlKey;
 
     /**
      * @param {string} key;
-     * @param {SchemaController} ctrl 
+     * @param {string} modelCtrlKey 
+     * @param {string} unique 
      */
-    constructor( key, ctrl, unique = "" ) {
+    constructor( key, modelCtrlKey, unique = "" ) {
 
         super( `${ctrl.key}.${key}` + (unique && `.${unique}`) );
 
         this.key = key;
         this.prop = key+"s";
-        this.ctrl = ctrl;
+        this.modelCtrlKey = modelCtrlKey;
 
+    }
+
+    /**
+     * @returns {SchemaController}
+     */
+    get modelCtrl() {
+        return this.effect( this.modelCtrlKey );
     }
 
     /**
@@ -83,7 +91,7 @@ class SubSchemaController extends Controller {
      */
     async findOwner( { docId }, queryOptions ) {
 
-        return await this.ctrl.findOne({
+        return await this.modelCtrl.findOne({
             search: { [`${this.prop}._id`]: docId }
         }, queryOptions);
 
@@ -100,7 +108,7 @@ class SubSchemaController extends Controller {
         return (
 
             // Make the query.
-            await this.ctrl.updateOne({
+            await this.modelCtrl.updateOne({
                 docId: belongsTo,
                 data: { $push: { [this.prop]: data } }
             }, {
@@ -122,7 +130,7 @@ class SubSchemaController extends Controller {
         return (
 
             // Find and select the target subdoc.
-            await this.ctrl.findOne({
+            await this.modelCtrl.findOne({
                 search: { [`${this.prop}._id`]: docId }
             }, {
                 // Select the potential matching document.
@@ -157,7 +165,7 @@ class SubSchemaController extends Controller {
         return (
 
             // Find and update the target subdoc.
-            await this.ctrl.updateOne({
+            await this.modelCtrl.updateOne({
                 search: { [`${this.prop}._id`]: docId },
                 data: {
                     $set: {
@@ -186,7 +194,7 @@ class SubSchemaController extends Controller {
         return (
 
             // Find and update the target subdoc.
-            await this.ctrl.updateOne({
+            await this.modelCtrl.updateOne({
                 search: { [`${this.prop}._id`]: docId },
                 data: { $pull: { [`${this.prop}`]: { "_id": docId } } },
                 // Return the old document so we can extract the deleted student.

--- a/app/controllers/types/SubSchemaController.js
+++ b/app/controllers/types/SubSchemaController.js
@@ -1,8 +1,9 @@
 const { InvalidDataError } = require("../../config/errors");
-const { populate } = require("../definitions/models/Feed");
 
 const Controller = require("./Controller");
 const SchemaController = require("./SchemaController");
+
+const library = require("./library");
 
 /**
  * TYPE DEFINITION IMPORTS
@@ -55,7 +56,9 @@ class SubSchemaController extends Controller {
      */
     constructor( key, modelCtrlKey, unique = "" ) {
 
-        super( `${ctrl.key}.${key}` + (unique && `.${unique}`) );
+        if( !library.has(modelCtrlKey) ) throw new Error("Cannot register SubSchemaController before their dependent SchemaController");
+
+        super( `${library.get(modelCtrlKey).key}.${key}` + (unique && `.${unique}`) );
 
         this.key = key;
         this.prop = key+"s";

--- a/app/controllers/types/library.js
+++ b/app/controllers/types/library.js
@@ -1,0 +1,3 @@
+const instanceLibrary = new Map();
+
+module.exports = instanceLibrary;

--- a/app/routes/utils/addRequest.js
+++ b/app/routes/utils/addRequest.js
@@ -47,7 +47,7 @@ const subSchemaCtrlMap = {
     post: subCtrl => [ subCtrl.binding.createOne, {
         keyMap: {
             body: "data",
-            [`${subCtrl.ctrl.key}Id`]: "belongsTo",
+            [`${subCtrl.modelCtrl.key}Id`]: "belongsTo",
             user: "createdBy"
         }
     } ],


### PR DESCRIPTION
Reconfigured the strategy for how Sub Schema Controllers access their parent Schema Controller so they don't require importing the parent controller instance.

- `SubSchemaController` now accepts the ctrlKey for the parent model ctrl instead of accepting the model ctrl itself.
- Added `SubSchemaController.modelCtrlKey` property
- Refactored `SubSchemaController.ctrl` -> `SubSchemaController.modelCtrl`. SubSchemaController.modelCtrl is now a dynamic property that returns the linked model controller through the `effect()` method.
- Updated `FeedEntryController` and `StudentController` to conform to new `SubSchemaController` requirements.
- Pulled the controller instance `library` out into it's own export to make it sharable between files.
- Updated `SubSchemaController.constructor` to get the appropriate controller from the library using the provided key.