### PR TITLE
Added namespace solution to `Modal` to allow multiple instances

### DIFF
--- a/client/src/components/Modal/components/Modal.js
+++ b/client/src/components/Modal/components/Modal.js
@@ -3,21 +3,21 @@ import {
 } from "react-bulma-components";
 import { useOpenModal } from "components/Modal/utils";
 import { useModalContext } from "../store";
+import { useMemo } from "react";
 
 
-export const Modal = ( { onClose, contentProps = {}, ...props } ) => {
-
+export const Modal = ( { namespace = "default", onClose, contentProps = {}, ...props } ) => {
 
     const [ modal, ] = useModalContext();
-	const { modals, activeKey } = modal
+	const { modals, activeKey } = modal;
+
+	const isActive = useMemo(() => modals[activeKey] && modals[activeKey].namespace === namespace, [activeKey]);
 	
 	const { component: Component } = (
-		modals[activeKey] ? 
+		isActive ? 
 			modals[activeKey]: 
 			false
-		)
-
-    const isActive = () => activeKey
+		);
 
     const closeModal = useOpenModal(false);
 
@@ -27,7 +27,7 @@ export const Modal = ( { onClose, contentProps = {}, ...props } ) => {
 
     return (
 		<BulmaModal
-			show={isActive()}
+			show={isActive}
 			onClose={onModalClose}
 			closeOnBlur={true}
 			{...props}>

--- a/client/src/components/Modal/utils.js
+++ b/client/src/components/Modal/utils.js
@@ -10,7 +10,8 @@ export const useModalRegistration = ( key, modalConfig ) => {
         modalDispatch({
             type: REGISTER_MODAL,
             payload: { 
-                [ key ] : {  
+                [ key ] : {
+                    namespace: "default",  
                     ...modalConfig 
                 } 
             }

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -20,6 +20,7 @@ import { useSocket } from "utils/socket.io";
 import PendingVerification from "./components/PendingVerification";
 import Fade from "animations/Fade";
 import UserSettings from "./views/UserSettings";
+import { Modal } from "components/Modal";
 
 loadDashboardIcons();
 
@@ -101,6 +102,7 @@ const Dashboard = () => {
                 </Switch>
             </div>
             <Fade show={!isUserVerified}><PendingVerification /></Fade>
+            <Modal namespace="dashboard" />
         </DashboardProvider>
     );
 


### PR DESCRIPTION
- Added new `Modal` instance to `Dashboard`
- Updated Modal utils `useModalRegistration` to include a default namespace
- Update `Modal` to accept a `namespace` for determining appropriate modals to display