### PR TITLE
Feature/modular typedefs

### DIFF
--- a/app/graphql/modules/auth.js
+++ b/app/graphql/modules/auth.js
@@ -36,13 +36,13 @@ const auth = createModule({
 	},
 	resolvers: {
 		Query: {
-			authenticated: (parent, args, { db, authUser }) => {
-				return authUser;np
+			authenticated: (...[,, { authUser } ]) => {
+				return authUser;
 			}
 		},
 
 		Mutation: {
-			login: (parent, { credentials }, { db }) => {
+			login: (...[, { credentials }, { db }]) => {
 				return db.get("auth").login({ credentials });
 			}
 		}

--- a/app/graphql/modules/auth.js
+++ b/app/graphql/modules/auth.js
@@ -2,32 +2,26 @@ const { createModule, gql } = require('graphql-modules');
 
 const { useAuthentication } = require('../middleware');
 
+const {
+	inputs: {
+		Credentials
+	},
+    types: {
+        UserDocument,
+		Auth
+    }
+} = require('./typedefs');
+
 const auth = createModule({
 	id: 'auth',
 	dirname: __dirname,
 	typeDefs: [
+		UserDocument,
+		Auth,
+		Credentials,
 		gql`
-			type User {
-				_id: ID
-				email: String
-				isVerified: Boolean
-				name: String
-				classrooms: [ID]
-			}
-
-			type Auth {
-				token: String
-				success: Boolean
-				user: User
-			}
-
-			input Credentials {
-				email: String
-				password: String
-			}
-
 			type Query {
-				authenticated: User
+				authenticated: UserDocument
 			}
 
 			type Mutation {

--- a/app/graphql/modules/room.js
+++ b/app/graphql/modules/room.js
@@ -1,5 +1,19 @@
 const { gql } = require('graphql-modules');
 const { GraphQLJSONObject } = require('graphql-type-json');
+const {
+    scalars: {
+        JSONObject
+    },
+    types: {
+        RoomDocument,
+        AppTypeDocument,
+        StaffDocument,
+        StudentDocument,
+        FeedEntryCommentDocument,
+        FeedEntryComment,
+        UserDocument
+    }
+} = require('./typedefs');
 
 const { createControllerModule } = require('./utils');
 
@@ -7,76 +21,21 @@ const roomModule = createControllerModule({
     id: 'room',
 	dirname: __dirname,
 	typeDefs: [
+        JSONObject,
+        StaffDocument,
+        RoomDocument,
+        AppTypeDocument,
+        StudentDocument,
+        FeedEntryCommentDocument,
+        FeedEntryComment,
+        UserDocument,
         gql`
-            scalar JSONObject
-
-            type App {
-                id: ID
-                isDisabled: Boolean
-                name: String
-                type: String
-            }
-
-            type Invite {
-                id: ID
-            }
-
-            type Staff {
-                _id: ID
-                date: String
-                meta: JSONObject
-                role: String
-                user: User
-            }
-
-            type Student {
-                _id: ID
-                assignedTo: String
-                date: String
-                elevation: Int
-                feed: String
-                meta: JSONObject
-                name: String
-                priorityLevel: Int
-                recentComments: [Comment]
-            }
-
-            type User {
-				_id: ID
-                date: String
-				email: String
-				name: String
-			}
-
-            type Comment {
-                _id: ID
-                action: String
-                by: String
-                data: CommentValueJSON
-                date: String
-            }
-
-            type CommentValueJSON {
-                feedId: ID
-                comment: JSONObject
-            }
-
-			type Classroom {
-				_id: ID
-                apps: [ App ]
-                date: String
-                invites: [ Invite ]
-                name: String
-                staff: [ Staff ]
-                students: [ Student ]
-			}
-
             type Query {
-				room(roomId: ID): Classroom
+				room(roomId: ID): RoomDocument
 			}
 
             type Mutation {
-				room(roomId: ID, ): Classroom
+				room(roomId: ID, ): RoomDocument
 			}
         `
     ],

--- a/app/graphql/modules/typedefs/index.js
+++ b/app/graphql/modules/typedefs/index.js
@@ -1,0 +1,7 @@
+const types = require('./types');
+const scalars = require('./scalars');
+
+module.exports = {
+    scalars,
+    types
+}

--- a/app/graphql/modules/typedefs/index.js
+++ b/app/graphql/modules/typedefs/index.js
@@ -1,7 +1,9 @@
 const types = require('./types');
 const scalars = require('./scalars');
+const inputs = require('./inputs');
 
 module.exports = {
     scalars,
-    types
+    types,
+    inputs
 }

--- a/app/graphql/modules/typedefs/inputs/Credentials.js
+++ b/app/graphql/modules/typedefs/inputs/Credentials.js
@@ -1,0 +1,10 @@
+const { gql } = require('graphql-modules');
+
+const Credentials = gql`
+    input Credentials {
+        email: String
+        password: String
+    }
+`;
+
+exports.Credentials = Credentials;

--- a/app/graphql/modules/typedefs/inputs/index.js
+++ b/app/graphql/modules/typedefs/inputs/index.js
@@ -1,0 +1,5 @@
+const { Credentials } = require("./Credentials");
+
+module.exports = {
+    Credentials
+}

--- a/app/graphql/modules/typedefs/scalars/JSONObject.js
+++ b/app/graphql/modules/typedefs/scalars/JSONObject.js
@@ -1,0 +1,5 @@
+const { gql } = require('graphql-modules');
+
+const JSONObject = gql`scalar JSONObject`;
+
+exports.JSONObject = JSONObject;

--- a/app/graphql/modules/typedefs/scalars/index.js
+++ b/app/graphql/modules/typedefs/scalars/index.js
@@ -1,0 +1,5 @@
+const { JSONObject } = require("./JSONObject");
+
+module.exports = {
+    JSONObject
+}

--- a/app/graphql/modules/typedefs/types/AppTypeDocument.js
+++ b/app/graphql/modules/typedefs/types/AppTypeDocument.js
@@ -1,0 +1,14 @@
+const { gql } = require('graphql-modules');
+
+const AppTypeDocument = gql`
+    type AppTypeDocument {
+        id: ID
+        isDisabled: Boolean
+        name: String
+        type: String
+    }
+`;
+
+exports.AppTypeDocument = AppTypeDocument;
+
+            

--- a/app/graphql/modules/typedefs/types/AppTypeDocument.js
+++ b/app/graphql/modules/typedefs/types/AppTypeDocument.js
@@ -10,5 +10,3 @@ const AppTypeDocument = gql`
 `;
 
 exports.AppTypeDocument = AppTypeDocument;
-
-            

--- a/app/graphql/modules/typedefs/types/Auth.js
+++ b/app/graphql/modules/typedefs/types/Auth.js
@@ -1,0 +1,11 @@
+const { gql } = require('graphql-modules');
+
+const Auth = gql`
+    type Auth {
+        token: String
+        success: Boolean
+        user: UserDocument
+    }
+`;
+
+exports.Auth = Auth;

--- a/app/graphql/modules/typedefs/types/FeedEntryComment.js
+++ b/app/graphql/modules/typedefs/types/FeedEntryComment.js
@@ -1,0 +1,12 @@
+const { gql } = require('graphql-modules');
+
+const FeedEntryComment = gql`
+    type FeedEntryComment {
+        feedId: ID
+        comment: JSONObject
+    }
+`;
+
+exports.FeedEntryComment = FeedEntryComment;
+
+            

--- a/app/graphql/modules/typedefs/types/FeedEntryCommentDocument.js
+++ b/app/graphql/modules/typedefs/types/FeedEntryCommentDocument.js
@@ -1,0 +1,15 @@
+const { gql } = require('graphql-modules');
+
+const FeedEntryCommentDocument = gql`
+    type FeedEntryCommentDocument {
+        _id: ID
+        action: String
+        by: String
+        data: FeedEntryComment
+        date: String
+    }
+`;
+
+exports.FeedEntryCommentDocument = FeedEntryCommentDocument;
+
+            

--- a/app/graphql/modules/typedefs/types/FeedEntryDocument.js
+++ b/app/graphql/modules/typedefs/types/FeedEntryDocument.js
@@ -1,0 +1,15 @@
+const { gql } = require('graphql-modules');
+
+const FeedEntryDocument = gql`
+    type FeedEntryDocument {
+        _id: ID
+        action: String
+        by: String
+        data: FeedEntryComment
+        date: String
+    }
+`;
+
+exports.FeedEntryDocument = FeedEntryDocument;
+
+            

--- a/app/graphql/modules/typedefs/types/RoomDocument.js
+++ b/app/graphql/modules/typedefs/types/RoomDocument.js
@@ -1,0 +1,19 @@
+const { gql } = require('graphql-modules');
+
+const RoomDocument = gql`
+    type Invite {
+        id: ID
+    }
+
+    type RoomDocument {
+        _id: ID
+        apps: [ AppTypeDocument ]
+        date: String
+        invites: [ Invite ]
+        name: String
+        staff: [ StaffDocument ]
+        students: [ StudentDocument ]
+    }
+`;
+
+exports.RoomDocument = RoomDocument;

--- a/app/graphql/modules/typedefs/types/StaffDocument.js
+++ b/app/graphql/modules/typedefs/types/StaffDocument.js
@@ -1,0 +1,15 @@
+const { gql } = require('graphql-modules');
+
+const StaffDocument = gql`
+    type StaffDocument {
+        _id: ID
+        date: String
+        meta: JSONObject
+        role: String
+        user: UserDocument
+    }
+`;
+
+exports.StaffDocument = StaffDocument;
+
+            

--- a/app/graphql/modules/typedefs/types/StudentDocument.js
+++ b/app/graphql/modules/typedefs/types/StudentDocument.js
@@ -1,0 +1,17 @@
+const { gql } = require('graphql-modules');
+
+const StudentDocument = gql`
+    type StudentDocument {
+        _id: ID
+        assignedTo: String
+        date: String
+        elevation: Int
+        feed: String
+        meta: JSONObject
+        name: String
+        priorityLevel: Int
+        recentComments: [ FeedEntryCommentDocument ]
+    }
+`;
+
+exports.StudentDocument = StudentDocument;

--- a/app/graphql/modules/typedefs/types/UserDocument.js
+++ b/app/graphql/modules/typedefs/types/UserDocument.js
@@ -1,0 +1,14 @@
+const { gql } = require('graphql-modules');
+
+const UserDocument = gql`
+    type UserDocument {
+        _id: ID
+        date: String
+        email: String
+        name: String
+    }
+`;
+
+exports.UserDocument = UserDocument;
+
+            

--- a/app/graphql/modules/typedefs/types/UserDocument.js
+++ b/app/graphql/modules/typedefs/types/UserDocument.js
@@ -6,9 +6,8 @@ const UserDocument = gql`
         date: String
         email: String
         name: String
+        classrooms: [ID]
     }
 `;
 
 exports.UserDocument = UserDocument;
-
-            

--- a/app/graphql/modules/typedefs/types/index.js
+++ b/app/graphql/modules/typedefs/types/index.js
@@ -6,6 +6,7 @@ const { UserDocument } = require("./UserDocument");
 const { FeedEntryDocument } = require("./FeedEntryDocument");
 const { FeedEntryCommentDocument } = require("./FeedEntryCommentDocument");
 const { FeedEntryComment } = require("./FeedEntryComment");
+const { Auth } = require("./Auth");
 
 module.exports = {
     RoomDocument,
@@ -15,5 +16,6 @@ module.exports = {
     UserDocument,
     FeedEntryDocument,
     FeedEntryCommentDocument,
-    FeedEntryComment
+    FeedEntryComment,
+    Auth
 }

--- a/app/graphql/modules/typedefs/types/index.js
+++ b/app/graphql/modules/typedefs/types/index.js
@@ -1,0 +1,19 @@
+const { RoomDocument } = require("./RoomDocument");
+const { AppTypeDocument } = require("./AppTypeDocument");
+const { StaffDocument } = require("./StaffDocument");
+const { StudentDocument } = require("./StudentDocument");
+const { UserDocument } = require("./UserDocument");
+const { FeedEntryDocument } = require("./FeedEntryDocument");
+const { FeedEntryCommentDocument } = require("./FeedEntryCommentDocument");
+const { FeedEntryComment } = require("./FeedEntryComment");
+
+module.exports = {
+    RoomDocument,
+    AppTypeDocument,
+    StaffDocument,
+    StudentDocument,
+    UserDocument,
+    FeedEntryDocument,
+    FeedEntryCommentDocument,
+    FeedEntryComment
+}


### PR DESCRIPTION
Beginning steps for breaking apart graphql typedefs into a modular structure
- Refactored `room` and `auth` module typdefs into modular files organized by `inputs`, `scalars`, and `types`
- Refactored some naming conventions for types for better clarity and some future case handling